### PR TITLE
Cargo: Consume nvme-mi-dev as a regular crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -310,8 +310,18 @@ version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
 dependencies = [
- "darling_core",
- "darling_macro",
+ "darling_core 0.20.11",
+ "darling_macro 0.20.11",
+]
+
+[[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
 ]
 
 [[package]]
@@ -329,12 +339,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
- "darling_core",
+ "darling_core 0.20.11",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn",
 ]
@@ -345,17 +380,19 @@ version = "0.19.1"
 source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3#d68915c71e1b3ac76726328803eeffc773fb9871"
 dependencies = [
  "bitvec",
- "deku_derive 0.19.1 (git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3)",
+ "deku_derive 0.19.1",
  "no_std_io2",
  "rustversion",
 ]
 
 [[package]]
 name = "deku"
-version = "0.19.1"
-source = "git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebf55291257a2a5c90cf50ae17b6bbaabc3fd13642cf3895a71c412513c19630"
 dependencies = [
- "deku_derive 0.19.1 (git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432)",
+ "bitvec",
+ "deku_derive 0.20.3",
  "no_std_io2",
  "rustversion",
 ]
@@ -365,7 +402,7 @@ name = "deku_derive"
 version = "0.19.1"
 source = "git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3#d68915c71e1b3ac76726328803eeffc773fb9871"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -373,10 +410,11 @@ dependencies = [
 
 [[package]]
 name = "deku_derive"
-version = "0.19.1"
-source = "git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432#e5363bc11e123bfcfd3467a2a90aeef8b588f432"
+version = "0.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bec2a42b511fc5efd9183f4f71c17885d627b17e7fd9a61a92089406caa4397e"
 dependencies = [
- "darling",
+ "darling 0.21.3",
  "proc-macro2",
  "quote",
  "syn",
@@ -463,7 +501,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76d07902c93376f1e96c34abc4d507c0911df3816cef50b01f5a2ff3ad8c370d"
 dependencies = [
- "darling",
+ "darling 0.20.11",
  "proc-macro2",
  "quote",
  "syn",
@@ -752,9 +790,9 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "log"
-version = "0.4.27"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "mctp"
@@ -814,9 +852,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "no_std_io2"
-version = "0.9.0"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c2b9acd47481ab557a89a5665891be79e43cce8a29ad77aa9419d7be5a7c06a"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
 dependencies = [
  "memchr",
 ]
@@ -859,10 +897,11 @@ dependencies = [
 [[package]]
 name = "nvme-mi-dev"
 version = "0.1.0"
-source = "git+https://github.com/CodeConstruct/nvme-mi-dev?branch=main#8b38ed3ab4e7189e7ed667a662fbd191d0a80e4b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec59529e84f5dcaa7b6ac83c411f513df0a1edf434790b30257b7797e29080ae"
 dependencies = [
  "crc",
- "deku 0.19.1 (git+https://github.com/sharksforarms/deku.git?rev=e5363bc11e123bfcfd3467a2a90aeef8b588f432)",
+ "deku 0.20.3",
  "flagset",
  "heapless",
  "hmac",
@@ -919,7 +958,7 @@ version = "0.2.0"
 source = "git+https://github.com/CodeConstruct/mctp-rs?rev=77da3b1c4d35b7c9ba37747da968d29fc4cde696#77da3b1c4d35b7c9ba37747da968d29fc4cde696"
 dependencies = [
  "crc",
- "deku 0.19.1 (git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3)",
+ "deku 0.19.1",
  "heapless",
  "log",
  "mctp",
@@ -933,7 +972,7 @@ version = "0.1.0"
 source = "git+https://github.com/CodeConstruct/mctp-rs?rev=77da3b1c4d35b7c9ba37747da968d29fc4cde696#77da3b1c4d35b7c9ba37747da968d29fc4cde696"
 dependencies = [
  "crc",
- "deku 0.19.1 (git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3)",
+ "deku 0.19.1",
  "enumset",
  "log",
  "mctp",
@@ -948,7 +987,7 @@ version = "0.1.0"
 source = "git+https://github.com/CodeConstruct/mctp-rs?rev=77da3b1c4d35b7c9ba37747da968d29fc4cde696#77da3b1c4d35b7c9ba37747da968d29fc4cde696"
 dependencies = [
  "chrono",
- "deku 0.19.1 (git+https://github.com/CodeConstruct/deku.git?tag=cc%2Fdeku-v0.19.1%2Fno-alloc-3)",
+ "deku 0.19.1",
  "heapless",
  "log",
  "mctp",
@@ -1029,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.21"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a0d197bd2c9dc6e53b84da9556a69ba4cdfab8619eb41a8bd1cc2027a0f6b1d"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
 name = "serde"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,10 +23,10 @@ embedded-io-async = { version = "0.6" }
 futures = "0.3.31"
 futures-io = "0.3.30"
 hex = { version = "0.4.3", optional = true }
-log = "0.4.22"
+log = "0.4.28"
 mctp = "0.2.0"
 mctp-estack = { git = "https://github.com/CodeConstruct/mctp-rs", rev = "77da3b1c4d35b7c9ba37747da968d29fc4cde696", package = "mctp-estack" }
-nvme-mi-dev = { git = "https://github.com/CodeConstruct/nvme-mi-dev", branch = "main", optional = true }
+nvme-mi-dev = { version = "0.1.0", optional = true }
 polling = "3.7.4"
 pldm = { git = "https://github.com/CodeConstruct/mctp-rs", rev = "77da3b1c4d35b7c9ba37747da968d29fc4cde696", package = "pldm", optional = true }
 pldm-file = { git = "https://github.com/CodeConstruct/mctp-rs", rev = "77da3b1c4d35b7c9ba37747da968d29fc4cde696", package = "pldm-file", optional = true }

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,9 +237,9 @@ async fn nvme_mi(router: &Router<'_>) -> std::io::Result<()> {
                 Ok(())
             }
             nvme_mi_dev::CommandEffect::SetSmbusFreq { port_id: _, freq } => {
-                use nvme_mi_dev::nvme::mi::SmbusFrequency;
+                use nvme_mi_dev::smbus::BusFrequency;
 
-                if freq != SmbusFrequency::Freq100Khz {
+                if freq != BusFrequency::Freq100Khz {
                     warn!("NVMe-MI: Application lacks support for I2C bus frequency {:?}", freq);
                     return Err(CommandEffectError::Unsupported);
                 }


### PR DESCRIPTION
To do so, adjust implementation and dependencies to meet the needs of nvme-mi-dev v0.1.0.